### PR TITLE
Multirun embedding

### DIFF
--- a/bend/io/datasets.py
+++ b/bend/io/datasets.py
@@ -9,7 +9,6 @@ The code here only handles iteration and conversion to torch tensors.
 import torch
 from bioio.tf.utils import load_tfrecord
 
-
 # %%
 class TFRecordIterableDataset(torch.utils.data.IterableDataset):
     """Iterable dataset for loading data from tfrecords.

--- a/bend/io/sequtils.py
+++ b/bend/io/sequtils.py
@@ -130,7 +130,7 @@ def embed_from_multilabled_bed_gen(bed, reference_fasta, embedder, label_column_
 
 
 def embed_from_bed(bed, reference_fasta, embedder, upsample_embeddings = False, 
-                  hdf5_file= None, read_strand = False, label_column_idx=6, label_depth=None, split = None):
+                  hdf5_file= None, read_strand = False, label_column_idx=6, label_depth=None, split = None, flank = 0):
     fasta = Fasta(reference_fasta)
     # open hdf5 file 
     hdf5_file = h5py.File(hdf5_file, mode = "r") if hdf5_file else None
@@ -153,7 +153,7 @@ def embed_from_bed(bed, reference_fasta, embedder, upsample_embeddings = False,
             labels = list(map(int, line[label_column_idx].split(',')))
             labels = multi_hot(labels, depth=label_depth)
         # get sequence
-        sequence = fasta.fetch(chrom, start, end, strand = strand) # categorical labels
+        sequence = fasta.fetch(chrom, start, end, strand = strand, flank = flank) # categorical labels
         # embed sequence
         sequence_embed = embedder(sequence, upsample_embeddings = upsample_embeddings)
         sequence_embed = tf.squeeze(tf.constant(sequence_embed))

--- a/bend/io/sequtils.py
+++ b/bend/io/sequtils.py
@@ -54,7 +54,7 @@ class Fasta():
         
         self._fasta = pysam.FastaFile(fasta)
     
-    def fetch(self, chrom: str, start: int, end: int, strand: str = '+') -> str:
+    def fetch(self, chrom: str, start: int, end: int, strand: str = '+', flank : int = 0) -> str:
         """
         Fetch a sequence from the reference genome fasta file.
 
@@ -69,13 +69,14 @@ class Fasta():
         strand : str, optional
             Strand. The default is '+'.
             If strand is '-', the sequence will be reverse-complemented before returning.
-        
+        flank : int, optional
+            Number of bases to add to the start and end coordinates. The default is 0.
         Returns
         -------
         str
             Sequence from the reference genome fasta file.
         """
-        sequence = self._fasta.fetch(str(chrom), start, end).upper()
+        sequence = self._fasta.fetch(str(chrom), start - flank, end + flank).upper()
         
         if strand == '+':
             pass

--- a/conf/embedding/embed.yaml
+++ b/conf/embedding/embed.yaml
@@ -6,10 +6,7 @@ hydra :
     - file://conf 
 data_dir : ./data/
 embedders_dir : ./pretrained_models/
-splits : 
-  - train
-  - valid 
-  - test
+splits : null
 models : 
   #- gena-lm-bigbird-base-t2t
   #- gena-lm-bert-large-t2

--- a/conf/embedding/embed.yaml
+++ b/conf/embedding/embed.yaml
@@ -2,33 +2,37 @@ defaults:
   - datadims : [label_dims,embedding_dims]
   - _self_
 hydra : 
+  mode : MULTIRUN
   searchpath:
     - file://conf 
+  sweeper:
+    params:
+      model: gena-lm-bigbird-base-t2t,
+             gena-lm-bert-large-t2,
+             hyenadna-tiny-1k,
+             hyenadna-small-32k,
+             hyenadna-medium-160k,
+             hyenadna-medium-450k,
+             hyenadna-large-1m,
+             dnabert6,
+             resnetlm,
+             awdlstm,
+             nt_transformer_ms,
+             nt_transformer_human_ref,
+             nt_transformer_1000g,
+             dnabert2,
+             onehot
+      task: gene_finding,
+            enhancer_annotation,
+            variant_effects,
+            histone_modification,
+            chromatin_accessibility
+
 data_dir : ./data/
 embedders_dir : ./pretrained_models/
 splits : null
-models : 
-  #- gena-lm-bigbird-base-t2t
-  #- gena-lm-bert-large-t2
-  #- hyenadna-tiny-1k
-  #- hyenadna-small-32k
-  #- hyenadna-medium-160k
-  #- hyenadna-medium-450k
-  #- hyenadna-large-1m
-  #- dnabert6
-  #- resnetlm
-  #- awdlstm
-  #- nt_transformer_ms
-  #- nt_transformer_human_ref
-  #- nt_transformer_1000g
-  #- dnabert2
-  #- onehot
-tasks : 
-  #- gene_finding
-  #- enhancer_annotation
-  #- variant_effects
-  - histone_modification
-  #- chromatin_accessibility
+model : nt_transformer_1000g
+task : gene_finding
 # model instatiators 
 dnabert2:
   _target_ : bend.utils.embedders.DNABert2Embedder

--- a/conf/supervised_tasks/enhancer_annotation/awdlstm.yaml
+++ b/conf/supervised_tasks/enhancer_annotation/awdlstm.yaml
@@ -2,13 +2,13 @@ defaults:
   - datadims : [label_dims,embedding_dims]
   - _self_
 hydra :
-  mode : MULTIRUN
+  #mode : MULTIRUN
   searchpath:
     #- pkg://conf
     - file://conf 
-  sweeper:
-    params:
-      data.cross_validation: range(1,11)
+  #sweeper:
+  #  params:
+  #    data.cross_validation: range(1,11)
 task : enhancer_annotation 
 embedder : awdlstm
 output_dir: ./downstream_tasks/${task}/${embedder}/split_${data.cross_validation}
@@ -26,13 +26,12 @@ optimizer :
   weight_decay: 0.01
 data:
   _target_: bend.utils.data_downstream.get_data
-  cross_validation : false
   batch_size : 8
   num_workers : 0
   padding_value : -100
   shuffle : 500
   data_dir : ./data/${task}/${embedder}/
-  #cross_validation : 1 # which split to run in the cross validation
+  cross_validation : 1 # which split to run in the cross validation
 params:
   epochs: 100
   load_checkpoint: true

--- a/conf/supervised_tasks/enhancer_annotation/dnabert2.yaml
+++ b/conf/supervised_tasks/enhancer_annotation/dnabert2.yaml
@@ -25,7 +25,7 @@ data:
   batch_size : 8
   num_workers : 0
   padding_value : -100
-  shuffle : 500
+  shuffle : 100
   data_dir : ./data/${task}/${embedder}/
   cross_validation : 1 # which split to run in the cross validation
 params:

--- a/conf/supervised_tasks/enhancer_annotation/gena-lm-bert-large-t2.yaml
+++ b/conf/supervised_tasks/enhancer_annotation/gena-lm-bert-large-t2.yaml
@@ -25,7 +25,7 @@ data:
   batch_size : 8
   num_workers : 0
   padding_value : -100
-  shuffle : 500
+  shuffle : 100
   data_dir : ./data/${task}/${embedder}/
   cross_validation : 1 # which split to run in the cross validation
 params:

--- a/conf/supervised_tasks/enhancer_annotation/nt_transformer_ms.yaml
+++ b/conf/supervised_tasks/enhancer_annotation/nt_transformer_ms.yaml
@@ -25,7 +25,7 @@ data:
   batch_size : 4
   num_workers : 0
   padding_value : -100
-  shuffle : 500
+  shuffle : 100
   data_dir : ./data/${task}/${embedder}/
   cross_validation : 1 # which split to run in the cross validation
 params:

--- a/conf/supervised_tasks/histone_modification/dnabert2.yaml
+++ b/conf/supervised_tasks/histone_modification/dnabert2.yaml
@@ -23,16 +23,16 @@ data:
   _target_: bend.utils.data_downstream.get_data
   data_dir : ./data/${task}/${embedder}/
   cross_validation : false
-  batch_size : 64
-  num_workers : 1
+  batch_size : 256
+  num_workers : 0
   padding_value : -100
-  shuffle : 5000
+  shuffle : 200
   train_data : [train.tfrecord]
   valid_data : [valid.tfrecord]
   test_data :  [test.tfrecord]
 params:
   epochs: 100
-  load_checkpoint: false
+  load_checkpoint: true
   mode: train
   gradient_accumulation_steps: 1
   criterion: bce

--- a/conf/supervised_tasks/histone_modification/gena-lm-bert-large-t2.yaml
+++ b/conf/supervised_tasks/histone_modification/gena-lm-bert-large-t2.yaml
@@ -22,16 +22,16 @@ data:
   _target_: bend.utils.data_downstream.get_data
   data_dir : ./data/${task}/${embedder}/
   cross_validation : false
-  batch_size : 64
+  batch_size : 256
   num_workers : 0
   padding_value : -100
-  shuffle : 5000
+  shuffle : 200
   train_data : [train.tfrecord]
   valid_data : [valid.tfrecord]
   test_data :  [test.tfrecord]
 params:
   epochs: 100
-  load_checkpoint: false
+  load_checkpoint: true
   mode: train
   gradient_accumulation_steps: 1
   criterion: bce

--- a/conf/supervised_tasks/histone_modification/gena-lm-bigbird-base-t2t.yaml
+++ b/conf/supervised_tasks/histone_modification/gena-lm-bigbird-base-t2t.yaml
@@ -26,13 +26,13 @@ data:
   batch_size : 256
   num_workers : 0
   padding_value : -100
-  shuffle : 5000
+  shuffle : 200
   train_data : [train.tfrecord]
   valid_data : [valid.tfrecord]
   test_data :  [test.tfrecord]
 params:
   epochs: 100
-  load_checkpoint: false
+  load_checkpoint: true
   mode: train
   gradient_accumulation_steps: 1
   criterion: bce

--- a/scripts/precompute_embeddings.py
+++ b/scripts/precompute_embeddings.py
@@ -18,28 +18,27 @@ def run_experiment(cfg: DictConfig) -> None:
     cfg : DictConfig
         Hydra configuration object.
     """
-    for task in cfg.tasks:
-        print('Embedding data for', task)
-        # read the bed file and get the splits :  
-        if not 'splits' in cfg or cfg.splits is None:
-            splits = sequtils.get_splits(cfg[task].bed) 
-        else:
-            splits = cfg.splits
-        for model in cfg.models:
-            print('Embedding with', model) 
-            # instatiante model
-            embedder = hydra.utils.instantiate(cfg[model])
-            for split in splits:
-                print(f'Embedding {split} set')
-                output_dir = f'{cfg.data_dir}/{task}/{model}/'
-                os.makedirs(output_dir, exist_ok=True)
-                gen = sequtils.embed_from_bed(**cfg[task], embedder = embedder, split = split, 
-                                             upsample_embeddings = cfg[model]['upsample_embeddings'] if 'upsample_embeddings' in cfg[model] else False)
-                # save the embeddings to tfrecords 
-                dataset = dataset_from_iterable(gen)
-                dataset.element_spec
-                dataset_to_tfrecord(dataset, f'{output_dir}/{split}.tfrecord')
-
+    print('Embedding data for', cfg.task)
+    # read the bed file and get the splits :  
+    if not 'splits' in cfg or cfg.splits is None:
+        splits = sequtils.get_splits(cfg[cfg.task].bed) 
+    else:
+        splits = cfg.splits
+    print('Embedding with', cfg.model) 
+    # instatiante model
+    embedder = hydra.utils.instantiate(cfg[cfg.model])
+    for split in splits:
+        print(f'Embedding {split} set')
+        output_dir = f'{cfg.data_dir}/{cfg.task}/{cfg.model}/'
+        
+        os.makedirs(output_dir, exist_ok=True)
+        gen = sequtils.embed_from_bed(**cfg[task], embedder = embedder, split = split, 
+                                        upsample_embeddings = cfg.model['upsample_embeddings'] if 'upsample_embeddings' in cfg.model else False)
+        # save the embeddings to tfrecords 
+        dataset = dataset_from_iterable(gen)
+        dataset.element_spec
+        dataset_to_tfrecord(dataset, f'{output_dir}/{split}.tfrecord')
+        
 
 
 


### PR DESCRIPTION
- Changed embedding to run hydra multirun sweeper to make embedding script simpler/more elegant. Functionality is the same.  
- Added flank argument to bend.io.sequtils in [Fasta class](https://github.com/frederikkemarin/BEND/blob/d7909576dcf5a94f687255515344f3668a7eba5e/bend/io/sequtils.py#L57) and [embed_from_bed function](https://github.com/frederikkemarin/BEND/blob/d7909576dcf5a94f687255515344f3668a7eba5e/bend/io/sequtils.py#L132C5-L132C19). This is done in case different sequence window sizes want to be tested for classification tasks, without having to change bed file. 
