### PR TITLE
Add GROVER LM + fix some bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Embedders have a default-true argument `remove_special_tokens=True` in `embed()`
 |GENALMEmbedder | [Fishman et al.](https://www.biorxiv.org/content/10.1101/2023.06.12.544594v1) |[8 different models available](https://huggingface.co/AIRI-Institute) | |
 |HyenaDNAEmbedder | [Nguyen et al.](https://arxiv.org/abs/2306.15794) | [5 different models available](https://huggingface.co/LongSafari) | Experimental integration. Requires Git LFS to be installed to automatically download checkpoints. Instead of the HF checkpoint name, the argument when instantiating needs to be of the format `path/to/save/checkpoints/checkpoint_name` |
 |DNABert2Embedder | [Zhou et al.](https://arxiv.org/pdf/2306.15006v1.pdf) | [1 model available](https://huggingface.co/zhihan1996/DNABERT-2-117M) | |
+|GROVEREmbedder | [Sanabria et al.](https://www.biorxiv.org/content/10.1101/2023.07.19.549677v2) | [1 model available](https://zenodo.org/records/8373117) | The original BPE tokenizer is not available, so we apply MaxMatch for segmentation of the input sequence into tokens.|
 
 All embedders can be used as follows:
 ```python
@@ -120,6 +121,7 @@ The full list of current task names are :
 - `variant_effects`
 - `histone_modification`
 - `chromatin_accessibility`
+- `cpg_methylation`
 
 And the list of available embedders/models used for training on the tasks are : 
 
@@ -138,6 +140,7 @@ And the list of available embedders/models used for training on the tasks are :
 - `hyenadna-tiny-1k`
 - `hyenadna-small-32k`
 - `hyenadna-medium-160k`
+- `grover`
 
 
 The `train_on_task.py` script calls a trainer class `bend.utils.task_trainer`. All configurations required to adapt these 2 scripts to train on a specific task (input data, downstream model, parameters, evaluation metric etc.) are specified in the task specific [hydra](https://hydra.cc/docs/intro/) config files stored in the [conf](../conf/) directory. This minimizes the changes required to the scripts in order to introduce a potential new task. 
@@ -314,7 +317,7 @@ In case the variant consequences categories are used, [Ensembl VEP](https://geno
     doi = {10.1093/nar/gkz972},
     url = {https://doi.org/10.1093/nar/gkz972},
     eprint = {https://academic.oup.com/nar/article-pdf/48/D1/D835/31698033/gkz972.pdf},
-}
+    }
 
 
 

--- a/bend/utils/download.py
+++ b/bend/utils/download.py
@@ -40,3 +40,30 @@ def download_model(model: str = 'convnet',
         os.system(f'wget {url} -P {destination_dir}/')
 
     return 
+
+
+def download_model_zenodo(base_url: str, destination_dir: str = './pretrained_models'):
+    """
+    Download a HF model hosted as a Zenodo record.
+    Uses wget to download the files.
+    We use this to get the GROVER model, but it should work for any model hosted on Zenodo as a flat directory.
+
+    Parameters
+    ----------
+    base_url : str
+        Base URL to download from.
+    destination_dir : str
+        Destination directory to download to.
+        Default is ./pretrained_models/
+
+    Returns
+    -------
+    None.
+    """
+
+    os.makedirs(destination_dir, exist_ok=True)
+    # https://zenodo.org/records/8373117/files/training_args.bin?download=1
+    files = ['config.json', 'pytorch_model.bin', 'special_tokens_map.json', 'tokenizer.json', 'tokenizer_config.json', 'vocab.txt']
+    for file in files:
+        url = f'{base_url}/files/{file}'
+        os.system(f'wget {url} -P {destination_dir}/')

--- a/bend/utils/embedders.py
+++ b/bend/utils/embedders.py
@@ -951,6 +951,8 @@ class GROVEREmbedder(BaseEmbedder):
 
         self.max_length = 510 # NOTE this is BPE tokens, not bp.
 
+        self.max_token_length = max([len(token) for token in self.tokenizer.vocab.keys()])
+
 
     def max_match_tokenize(self, sequence: str) -> List[str]:
         """
@@ -973,7 +975,8 @@ class GROVEREmbedder(BaseEmbedder):
         i = 0
         while i < len(sequence):
             max_token = None
-            for j in range(len(sequence), i, -1):
+            for j in range(i + self.max_token_length, i, -1):
+            # for j in range(len(sequence), i, -1):
                 candidate = sequence[i:j]
                 if candidate in self.tokenizer.vocab:
                     max_token = candidate

--- a/bend/utils/embedders.py
+++ b/bend/utils/embedders.py
@@ -27,7 +27,7 @@ from bend.models.dilated_cnn import ConvNetModel
 from bend.models.gena_lm import BertModel as GenaLMBertModel
 from bend.models.hyena_dna import HyenaDNAPreTrainedModel, CharacterTokenizer
 from bend.models.dnabert2 import BertModel as DNABert2BertModel
-from bend.utils.download import download_model
+from bend.utils.download import download_model, download_model_zenodo
 
 from tqdm.auto import tqdm
 from transformers import logging, BertModel, BertConfig, BertTokenizer, AutoModel, AutoTokenizer, BigBirdModel, AutoModelForMaskedLM
@@ -896,6 +896,169 @@ class DNABert2Embedder(BaseEmbedder):
     
     
 
+    # GATTTATTAGGGGAGATTTTATATATCCCGA
+    # ['[CLS]', 'G', 'ATTTATT', 'AGGGG', 'AGATT', 'TTATAT', 'ATCCCG', 'A', '[SEP]']
+    @staticmethod
+    def _repeat_embedding_vectors(tokens: Iterable[str], embeddings: np.ndarray, has_special_tokens: bool = True):
+        '''
+        Byte-pair encoding merges a variable number of letters into one token.
+        We need to repeat each token's embedding vector for each letter in the token.
+        '''
+        assert len(tokens) == embeddings.shape[1], 'Number of tokens and embeddings must match.'
+        new_embeddings = []
+        for idx, token in enumerate(tokens):
+
+            if has_special_tokens and (idx == 0 or idx == len(tokens) - 1):
+                new_embeddings.append(embeddings[:, [idx]]) # (1, 768)
+                continue
+            token_embedding = embeddings[:, [idx]] # (1, 768)
+            if token == '[UNK]':
+                new_embeddings.extend([token_embedding])
+            else:
+                new_embeddings.extend([token_embedding] * len(token))
+
+        # list of (1,1, 768) arrays
+        new_embeddings = np.concatenate(new_embeddings, axis=1)
+        return new_embeddings
+
+
+class GROVEREmbedder(BaseEmbedder):
+    '''Embed using the GROVER model https://www.biorxiv.org/content/10.1101/2023.07.19.549677v2'''
+
+    def load_model(self, model_path: str = "pretrained_models/grover" , **kwargs):
+        """Load the GROVER model.
+
+        Parameters
+        ----------
+        model_path : str
+            The path to the model directory.
+            If the model path does not exist, it will be downloaded from https://zenodo.org/records/8373117
+        """
+        # download model if not exists
+        if not os.path.exists(model_path):
+            print(f'Path {model_path} does not exists, model is downloaded from https://zenodo.org/records/8373117')
+            download_model_zenodo(
+                base_url = 'https://zenodo.org/records/8373117',
+                destination_dir = model_path
+                )
+
+
+        self.model = BertModel.from_pretrained(model_path)
+        self.tokenizer = BertTokenizer.from_pretrained(model_path, do_lower_case=False)
+
+        self.model.to(device)
+        self.model.eval()
+
+        self.max_length = 510 # NOTE this is BPE tokens, not bp.
+
+
+    def max_match_tokenize(self, sequence: str) -> List[str]:
+        """
+        Tokenize a sequence using max match. 
+        We have to do this as we do not have access to the BPE tokenizer used by GROVER.
+        We only have access to the vocabulary, so we find a sequence-to-token assignment
+        that uses the longest possible tokens.
+
+        Parameters
+        ----------
+        sequence : str
+            The sequence to tokenize.
+
+        Returns
+        -------
+        List[str]
+            The tokenized sequence.
+        """
+        tokens = []
+        i = 0
+        while i < len(sequence):
+            max_token = None
+            for j in range(len(sequence), i, -1):
+                candidate = sequence[i:j]
+                if candidate in self.tokenizer.vocab:
+                    max_token = candidate
+                    break
+            if max_token is None:
+                # If a subsequence cannot be tokenized, add each individual character as an unknown token
+                tokens.extend([self.tokenizer.unk_token for _ in sequence[i]])
+                i += 1
+            else:
+                tokens.append(max_token)
+                i += len(max_token)
+        return tokens
+
+
+    def embed(self, sequences: List[str], disable_tqdm: bool = False, remove_special_tokens: bool = True, upsample_embeddings: bool = False):
+        '''Embeds a list sequences using the GROVER model.
+        Note that the BPE tokenizer that GROVER used is not provided, we only
+        have access to the vocabulary used for tokenization. Instead,
+        we use max match to tokenize the sequence, so that each subsequence gets
+        tokenized as its longest token in the vocabulary. Not certain that this is 
+        identical to what a correctly instantiated BPE tokenizer would do.
+
+        Parameters
+        ----------
+        sequences : List[str]
+            List of sequences to embed.
+        disable_tqdm : bool, optional
+            Whether to disable the tqdm progress bar. Defaults to False.
+        remove_special_tokens : bool, optional
+            Whether to remove the CLS and SEP tokens from the embeddings. Defaults to True.
+        upsample_embeddings : bool, optional
+            Whether to upsample the embeddings to match the length of the input sequences. Defaults to False.
+
+        Returns
+        -------
+        embeddings : List[np.ndarray]
+            List of embeddings.
+        '''
+        # '''
+        # Note that this model uses byte pair encoding.
+        # upsample_embedding repeats BPE token embeddings so that each nucleotide has its own embedding.
+        # The [CLS] and [SEP] tokens are removed from the output if remove_special_tokens is True.
+        # '''
+        embeddings = []
+        with torch.no_grad():
+            for sequence in tqdm(sequences, disable=disable_tqdm):
+
+                # pre-tokenize to BPE words
+                sequence_toks = self.max_match_tokenize(sequence)
+                chunks = [sequence_toks[chunk : chunk + self.max_length] for chunk in  range(0, len(sequence_toks), self.max_length)] # split bpe tokens into chunks
+                embedded_chunks = []
+                for n_chunk, chunk in enumerate(chunks):
+
+                    input_ids = self.tokenizer(' '.join(chunk), return_tensors="pt", return_attention_mask=False, return_token_type_ids=False)["input_ids"]
+                    output = self.model(input_ids.to(device))[0].detach().cpu().numpy()
+
+                    if upsample_embeddings:
+                        output = self._repeat_embedding_vectors(self.tokenizer.convert_ids_to_tokens(input_ids[0]), output)
+
+                    # for intermediate chunks the special tokens need to go.
+                    # if we only have 1 chunk, keep them for now.
+                    if len(chunks) != 1:
+                        if n_chunk == 0:
+                            output = output[:,:-1] # no SEP
+                        elif n_chunk == len(chunks) - 1:
+                            output = output[:,1:] # no CLS
+                        else:
+                            output = output[:,1:-1] # no CLS and no SEP
+
+                    embedded_chunks.append(output)
+
+                embedding = np.concatenate(embedded_chunks, axis=1)
+
+                if remove_special_tokens:
+                    embedding = embedding[:,1:-1]
+
+                if upsample_embeddings and remove_special_tokens:
+                    assert len(sequence) == embedding.shape[1], f'Number of tokens and embeddings must match. {len(sequence)} != {embedding.shape[1]}'
+                elif upsample_embeddings:
+                    assert len(sequence)+ 2 == embedding.shape[1], f'Number of tokens and embeddings must match. {len(sequence)+ 2} != {embedding.shape[1]}'
+
+                embeddings.append(embedding)
+
+        return embeddings
+    
     # GATTTATTAGGGGAGATTTTATATATCCCGA
     # ['[CLS]', 'G', 'ATTTATT', 'AGGGG', 'AGATT', 'TTATAT', 'ATCCCG', 'A', '[SEP]']
     @staticmethod

--- a/bend/utils/retrieve_from_bed.py
+++ b/bend/utils/retrieve_from_bed.py
@@ -39,7 +39,7 @@ class Annotation:
         # '''
         if annotation is not None:
             if isinstance(annotation, str):
-                annotation = pd.read_csv(annotation, sep = '\s+')
+                annotation = pd.read_csv(annotation, sep = '\t')
 
             self.annotation = annotation
         if reference_genome is not None: 

--- a/bend/utils/task_trainer.py
+++ b/bend/utils/task_trainer.py
@@ -554,7 +554,8 @@ class BaseTrainer:
             if self.config.params.metric == 'mcc':
                 columns = ['test_loss', f'test_{self.config.params.metric}'] +[f'test_recall_{n}' for n in range(int((len(metric)-1)/2))] + [f'test_precision_{n}' for n in range(int((len(metric)-1)/2))]
             else: 
-                columns = ['test_loss', f'test_{self.config.params.metric}_avg'] +[f'test_{self.config.params.metric}_{n}' for n in range(len(metric))]
+                # assumes metric[0] (the stopping metric) is the average of the other metrics
+                columns = ['test_loss', f'test_{self.config.params.metric}_avg'] +[f'test_{self.config.params.metric}_{n}' for n in range(len(metric)-1)]
         else:
             columns = ['test_loss', f'test_{self.config.params.metric}']
             data = [[loss, metric[0]]]

--- a/bend/utils/task_trainer.py
+++ b/bend/utils/task_trainer.py
@@ -10,7 +10,7 @@ import os
 from sklearn.metrics import matthews_corrcoef, roc_auc_score, recall_score, precision_score, average_precision_score, confusion_matrix
 from sklearn.feature_selection import r_regression
 import pandas as pd
-from typing import Union
+from typing import Union, List
 import numpy as np
 import glob
 import pandas as pd
@@ -270,7 +270,7 @@ class BaseTrainer:
         # wandb.log({"Training latent with labels": wandb.Image(plt)})
         return
     
-    def _calculate_metric(self, y_true, y_pred):
+    def _calculate_metric(self, y_true, y_pred) -> List[float]:
         ''' 
         Calculates the metric for the given task
         The metric calculated is specified in the config.params.metric
@@ -278,7 +278,8 @@ class BaseTrainer:
             y_true: true labels
             y_pred: predicted labels
         Returns:
-            metric (str): the metric value [mcc, auroc, pearsonr, auprc]
+            metric: list of metrics. The first element is the main metric,
+                    the remaining elements are detailed metrics depending on the task
         '''
         
         # check if any padding in the target
@@ -294,7 +295,7 @@ class BaseTrainer:
             #tp = confusion_matrix(y_true.numpy().ravel(), y_pred.numpy().ravel(), normalize='true').diagonal().tolist()
             metric = [metric] + recall + precision #[list(i) for i in zip(recall, precision)]
         elif self.config.params.metric == 'auroc':
-            if self.config.task == 'histone_modification' or self.config.task == 'chromatin_accessibility':
+            if self.config.task in ['histone_modification', 'chromatin_accessibility', 'cpg_methylation']:
                 # save y_true and y_pred 
                 metric = roc_auc_score(y_true.numpy(), y_pred.numpy(), average = None)
                 metric = [metric.mean()] + metric.tolist()
@@ -304,9 +305,11 @@ class BaseTrainer:
         elif self.config.params.metric == 'pearsonr':
             metric = r_regression(y_true.detach().numpy().reshape(-1,1), 
                                     y_pred.detach().numpy().ravel())[0] # flatten arrays to get pearsons r
+            metric = [metric]
 
         elif self.config.params.metric == 'auprc' :
             metric = average_precision_score(y_true.numpy().ravel(), y_pred.numpy().ravel(), average='macro')
+            metric = [metric]
             
         return metric
     
@@ -416,8 +419,8 @@ class BaseTrainer:
 
         for epoch in range(1+ start_epoch, epochs + 1):
             train_loss = self.train_epoch(train_loader)
-            val_loss, val_metric = self.validate(val_loader)
-            val_metric = np.mean(val_metric)
+            val_loss, val_metrics = self.validate(val_loader)
+            val_metric = val_metrics[0]
             #test_loss, test_metric = self.test(test_loader, overwrite=False)
             #print('TEST:', test_loss, test_metric, checkpoint = epoch)
             # save epoch in output dir
@@ -477,8 +480,8 @@ class BaseTrainer:
         -------
         loss : float
             The average validation loss.
-        metric : float
-            The average validation metric.
+        metrics : list
+            The values of the validation metrics.
         """
         self.model.eval()
         loss = 0
@@ -500,12 +503,12 @@ class BaseTrainer:
         # compute metrics
         # save targets and outputs 
         try:
-            metric = self._calculate_metric(torch.cat(targets_all), 
+            metrics = self._calculate_metric(torch.cat(targets_all), 
                                               torch.cat(outputs))
         except:
-            metric = self._calculate_metric(torch.cat([i.flatten() for i in targets_all]), 
+            metrics = self._calculate_metric(torch.cat([i.flatten() for i in targets_all]), 
                                               torch.cat([i.flatten() for i in outputs]))
-        return loss, metric
+        return loss, metrics
 
     def test(self, test_loader, checkpoint = None, overwrite=False):
         """
@@ -546,7 +549,7 @@ class BaseTrainer:
         #print(self.model.state_dict()['conv2.1.bias'])
         print(f'Test results : Loss {loss:.4f}, {self.config.params.metric} {metric[0]:.4f}')
         
-        if isinstance(metric, (np.ndarray, list)):
+        if len(metric) > 1:#, (np.ndarray, list)):
             data = [[loss] + list(metric)]
             if self.config.params.metric == 'mcc':
                 columns = ['test_loss', f'test_{self.config.params.metric}'] +[f'test_recall_{n}' for n in range(int((len(metric)-1)/2))] + [f'test_precision_{n}' for n in range(int((len(metric)-1)/2))]
@@ -554,7 +557,8 @@ class BaseTrainer:
                 columns = ['test_loss', f'test_{self.config.params.metric}_avg'] +[f'test_{self.config.params.metric}_{n}' for n in range(len(metric))]
         else:
             columns = ['test_loss', f'test_{self.config.params.metric}']
-            data = [[loss, metric]]
+            data = [[loss, metric[0]]]
+
         metrics = checkpoint.merge(pd.DataFrame(data = data, columns = columns), how = 'cross')
 
         if not overwrite and os.path.exists(f'{self.config.output_dir}/best_model_metrics.csv'):

--- a/conf/datadims/embedding_dims.yaml
+++ b/conf/datadims/embedding_dims.yaml
@@ -19,3 +19,4 @@ hyenadna-small-32k : 256
 hyenadna-medium-160k : 256
 hyenadna-medium-450k : 256
 nt_transformer_v2_500m: 1024
+grover: 768

--- a/conf/embedding/embed.yaml
+++ b/conf/embedding/embed.yaml
@@ -21,7 +21,8 @@ hydra :
              dnabert2,
              onehot, 
              awdlstm,
-             nt_transformer_v2_500m
+             nt_transformer_v2_500m,
+             grover
              #hyenadna-small-32k,
              #hyenadna-medium-160k,
              #hyenadna-medium-450k,
@@ -96,7 +97,10 @@ nt_transformer_v2_500m:
   _target_ : bend.utils.embedders.NucleotideTransformerEmbedder
   model_name: InstaDeepAI/nucleotide-transformer-v2-500m-multi-species
   upsample_embeddings: true
-  
+grover:
+  _target_ : bend.utils.embedders.GROVEREmbedder
+  model_name: ${embedders_dir}/grover/
+  upsample_embeddings: true
 # data configurations for each task
 gene_finding:
   reference_fasta : ${data_dir}/genomes/GRCh38.primary_assembly.genome.fa

--- a/conf/supervised_tasks/chromatin_accessibility.yaml
+++ b/conf/supervised_tasks/chromatin_accessibility.yaml
@@ -53,7 +53,7 @@ data:
   shuffle : 1000
 params:
   epochs: 100
-  load_checkpoint: true
+  load_checkpoint: false
   mode: train
   gradient_accumulation_steps: 1
   criterion: bce

--- a/conf/supervised_tasks/chromatin_accessibility.yaml
+++ b/conf/supervised_tasks/chromatin_accessibility.yaml
@@ -26,7 +26,8 @@ hydra :
                  awdlstm,
                  resnet-supervised,
                  basset-supervised,
-                 nt_transformer_v2_500m
+                 nt_transformer_v2_500m,
+                 grover
 embedder : onehot
 task : chromatin_accessibility 
 output_dir: ./downstream_tasks/${task}/${embedder}/

--- a/conf/supervised_tasks/cpg_methylation.yaml
+++ b/conf/supervised_tasks/cpg_methylation.yaml
@@ -25,7 +25,8 @@ hydra :
                  onehot,
                  awdlstm,
                  resnet-supervised,
-                 nt_transformer_v2_500m
+                 nt_transformer_v2_500m,
+                 grover
 embedder : onehot
 task : cpg_methylation 
 output_dir: ./downstream_tasks/${task}/${embedder}/

--- a/conf/supervised_tasks/cpg_methylation.yaml
+++ b/conf/supervised_tasks/cpg_methylation.yaml
@@ -52,7 +52,7 @@ data:
   shuffle : 200
 params:
   epochs: 100
-  load_checkpoint: true
+  load_checkpoint: false
   mode: train
   gradient_accumulation_steps: 1
   criterion: bce

--- a/conf/supervised_tasks/enhancer_annotation.yaml
+++ b/conf/supervised_tasks/enhancer_annotation.yaml
@@ -44,14 +44,14 @@ optimizer :
 data:
   _target_: bend.utils.data_downstream.get_data
   batch_size : 8
-  num_workers : 32
+  num_workers : 2
   padding_value : -100
   shuffle : 100
   parent_dir: ./data/
   data_dir : ${data.parent_dir}/${task}/${embedder}/
-  cross_validation : 1 # which split to run in the cross validation
+  cross_validation : 0 # which split to run in the cross validation
 params:
-  epochs: 80
+  epochs: 100
   load_checkpoint: false
   mode: train
   gradient_accumulation_steps: 1

--- a/conf/supervised_tasks/gene_finding.yaml
+++ b/conf/supervised_tasks/gene_finding.yaml
@@ -25,7 +25,8 @@ hydra :
                  onehot,
                  awdlstm,
                  resnet-supervised,
-                 nt_transformer_v2_500m
+                 nt_transformer_v2_500m,
+                 grover
 task : gene_finding 
 embedder : onehot
 output_dir: ./downstream_tasks/${task}/${embedder}/

--- a/conf/supervised_tasks/histone_modification.yaml
+++ b/conf/supervised_tasks/histone_modification.yaml
@@ -23,7 +23,8 @@ hydra :
                  awdlstm,
                  resnet-supervised,
                  basset-supervised,
-                 nt_transformer_v2_500m
+                 nt_transformer_v2_500m,
+                 grover
                  #hyenadna-small-32k,
                  #hyenadna-medium-160k,
                  #hyenadna-medium-450k,

--- a/scripts/predict_variant_effects.py
+++ b/scripts/predict_variant_effects.py
@@ -32,6 +32,7 @@ def main():
     # get the embedder
     if args.model == 'nt':
          embedder = embedders.NucleotideTransformerEmbedder(args.checkpoint)
+         kwargs['upsample_embeddings'] = True # each nucleotide has an embedding
     elif args.model == 'dnabert':
         embedder = embedders.DNABertEmbedder(args.checkpoint, kmer = args.kmer)
     elif args.model == 'awdlstm':

--- a/scripts/predict_variant_effects.py
+++ b/scripts/predict_variant_effects.py
@@ -16,7 +16,7 @@ def main():
     parser.add_argument('bed_file', type=str, help='Path to the bed file')
     parser.add_argument('out_file', type=str, help='Path to the output file')
     # model can be any of the ones supported by bend.utils.embedders
-    parser.add_argument('model', choices=['nt', 'dnabert', 'awdlstm', 'gpn', 'convnet', 'genalm', 'hyenadna'], type=str, help='Model architecture for computing embeddings')
+    parser.add_argument('model', choices=['nt', 'dnabert', 'awdlstm', 'gpn', 'convnet', 'genalm', 'hyenadna', 'dnabert2','grover'], type=str, help='Model architecture for computing embeddings')
     parser.add_argument('checkpoint', type=str, help='Path to or name of the model checkpoint')
     parser.add_argument('genome', type=str, help='Path to the reference genome fasta file')
     parser.add_argument('--extra_context', type=int, default=256, help='Number of extra nucleotides to include on each side of the sequence')
@@ -35,6 +35,9 @@ def main():
     elif args.model == 'dnabert':
         embedder = embedders.DNABertEmbedder(args.checkpoint, kmer = args.kmer)
     elif args.model == 'awdlstm':
+        # autogressive model. No use for right context.
+        extra_context_left = args.extra_context
+        extra_context_right = 0
         embedder = embedders.AWDLSTMEmbedder(args.checkpoint)
     elif args.model == 'gpn':
         embedder = embedders.GPNEmbedder(args.checkpoint)
@@ -48,12 +51,19 @@ def main():
         # autogressive model. No use for right context.
         extra_context_left = args.extra_context
         extra_context_right = 0
+    elif args.model == 'dnabert2':
+        embedder = embedders.DNABert2Embedder(args.checkpoint)
+        kwargs['upsample_embeddings'] = True # each nucleotide has an embedding
+    elif args.model == 'grover':
+        embedder = embedders.GROVEREmbedder(args.checkpoint)
+        kwargs['upsample_embeddings'] = True # each nucleotide has an embedding
     else:
         raise ValueError('Model not supported')
     
 
     # load the bed file
     genome_annotation = Annotation(args.bed_file, reference_genome=args.genome)
+
 
     # extend the segments if necessary
     if args.extra_context > 0:

--- a/scripts/run_variant_effects.sh
+++ b/scripts/run_variant_effects.sh
@@ -21,8 +21,9 @@ python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_
 python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_genalm_bert_large_t2t.csv genalm AIRI-Institute/gena-lm-bert-large-t2t ../GRCh38.primary_assembly.genome.fa --embedding_idx 256
 python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_genalm_bigbird_base_t2t.csv genalm AIRI-Institute/gena-lm-bigbird-base-t2t ../GRCh38.primary_assembly.genome.fa --embedding_idx 256
 python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_convnet.csv convnet pretrained_models/convnet data/genomes/GRCh38.primary_assembly.genome.fa --embedding_idx 256
-python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_awd_lstm.csv convnet pretrained_models/awd_lstm data/genomes/GRCh38.primary_assembly.genome.fa --embedding_idx 511 --extra_context 512 #autoreregressive
+python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_awd_lstm.csv awdlstm pretrained_models/awd_lstm data/genomes/GRCh38.primary_assembly.genome.fa --embedding_idx 511 --extra_context 512 #autoreregressive
 python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_nt_v2_500m.csv nt InstaDeepAI/nucleotide-transformer-v2-500m-multi-species data/genomes/GRCh38.primary_assembly.genome.fa --embedding_idx 42
+python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_grover.csv grover pretrained_models/grover data/genomes/GRCh38.primary_assembly.genome.fa --embedding_idx 256
 
 
 # Run disease variants.
@@ -45,5 +46,6 @@ python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_
 python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_genalm_bert_large_t2t.csv genalm AIRI-Institute/gena-lm-bert-large-t2t ../GRCh38.primary_assembly.genome.fa --embedding_idx 256
 python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_genalm_bigbird_base_t2t.csv genalm AIRI-Institute/gena-lm-bigbird-base-t2t ../GRCh38.primary_assembly.genome.fa --embedding_idx 256
 python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_convnet.csv convnet pretrained_models/convnet data/genomes/GRCh38.primary_assembly.genome.fa --embedding_idx 256
-python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_awd_lstm.csv convnet pretrained_models/awd_lstm data/genomes/GRCh38.primary_assembly.genome.fa --embedding_idx 511 --extra_context 512 #autoreregressive
+python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_awd_lstm.csv awdlstm pretrained_models/awd_lstm data/genomes/GRCh38.primary_assembly.genome.fa --embedding_idx 511 --extra_context 512 #autoreregressive
 python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_nt_v2_500m.csv nt InstaDeepAI/nucleotide-transformer-v2-500m-multi-species data/genomes/GRCh38.primary_assembly.genome.fa --embedding_idx 42
+python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_grover.csv grover pretrained_models/grover data/genomes/GRCh38.primary_assembly.genome.fa --embedding_idx 256

--- a/scripts/run_variant_effects.sh
+++ b/scripts/run_variant_effects.sh
@@ -9,10 +9,10 @@ mkdir -p $OUT_DIR
 
 python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_dnabert_6.csv dnabert pretrained_models/dnabert/6-new-12w-0 data/genomes/GRCh38.primary_assembly.genome.fa --embedding_idx 254 --kmer 6 # index 254 has the variant at its 3rd position in the 6-mer
 python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_dnabert2.csv dnabert2 zhihan1996/DNABERT-2-117M  data/genomes/GRCh38.primary_assembly.genome.fa --embedding_idx 256
-python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_nt_1000g_500m.csv nt InstaDeepAI/nucleotide-transformer-500m-1000g  data/genomes/GRCh38.primary_assembly.genome.fa --embedding_idx 42
-python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_nt_1000g_25b.csv nt InstaDeepAI/nucleotide-transformer-2.5b-1000g  data/genomes/GRCh38.primary_assembly.genome.fa --embedding_idx 42
-python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_nt_ms_25b.csv nt InstaDeepAI/nucleotide-transformer-2.5b-multi-species  data/genomes/GRCh38.primary_assembly.genome.fa --embedding_idx 42
-python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_nt_href_500m.csv nt InstaDeepAI/nucleotide-transformer-500m-human-ref  data/genomes/GRCh38.primary_assembly.genome.fa --embedding_idx 42
+python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_nt_1000g_500m.csv nt InstaDeepAI/nucleotide-transformer-500m-1000g  data/genomes/GRCh38.primary_assembly.genome.fa --embedding_idx 256
+python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_nt_1000g_25b.csv nt InstaDeepAI/nucleotide-transformer-2.5b-1000g  data/genomes/GRCh38.primary_assembly.genome.fa --embedding_idx 256
+python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_nt_ms_25b.csv nt InstaDeepAI/nucleotide-transformer-2.5b-multi-species  data/genomes/GRCh38.primary_assembly.genome.fa --embedding_idx 256
+python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_nt_href_500m.csv nt InstaDeepAI/nucleotide-transformer-500m-human-ref  data/genomes/GRCh38.primary_assembly.genome.fa --embedding_idx 256
 python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_hyenadna_tiny1k_512.csv hyenadna pretrained_models/hyenadna/hyenadna-tiny-1k-seqlen ../GRCh38.primary_assembly.genome.fa --extra_context 512 --embedding_idx 511 # autoreregressive
 python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_hyenadna_small32k_512.csv hyenadna pretrained_models/hyenadna/hyenadna-small-32k-seqlen ../GRCh38.primary_assembly.genome.fa --extra_context 512 --embedding_idx 511 # autoreregressive
 python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_hyenadna_medium160k_512.csv hyenadna pretrained_models/hyenadna/hyenadna-medium-160k-seqlen ../GRCh38.primary_assembly.genome.fa --extra_context 512 --embedding_idx 511 # autoreregressive
@@ -22,7 +22,7 @@ python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_
 python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_genalm_bigbird_base_t2t.csv genalm AIRI-Institute/gena-lm-bigbird-base-t2t ../GRCh38.primary_assembly.genome.fa --embedding_idx 256
 python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_convnet.csv convnet pretrained_models/convnet data/genomes/GRCh38.primary_assembly.genome.fa --embedding_idx 256
 python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_awd_lstm.csv awdlstm pretrained_models/awd_lstm data/genomes/GRCh38.primary_assembly.genome.fa --embedding_idx 511 --extra_context 512 #autoreregressive
-python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_nt_v2_500m.csv nt InstaDeepAI/nucleotide-transformer-v2-500m-multi-species data/genomes/GRCh38.primary_assembly.genome.fa --embedding_idx 42
+python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_nt_v2_500m.csv nt InstaDeepAI/nucleotide-transformer-v2-500m-multi-species data/genomes/GRCh38.primary_assembly.genome.fa --embedding_idx 256
 python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_grover.csv grover pretrained_models/grover data/genomes/GRCh38.primary_assembly.genome.fa --embedding_idx 256
 
 
@@ -34,10 +34,10 @@ mkdir -p $OUT_DIR
 
 python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_dnabert_6.csv dnabert pretrained_models/dnabert/6-new-12w-0 data/genomes/GRCh38.primary_assembly.genome.fa --embedding_idx 254 --kmer 6 # index 254 has the variant at its 3rd position in the 6-mer
 python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_dnabert2.csv dnabert2 zhihan1996/DNABERT-2-117M  data/genomes/GRCh38.primary_assembly.genome.fa --embedding_idx 256
-python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_nt_1000g_500m.csv nt InstaDeepAI/nucleotide-transformer-500m-1000g  data/genomes/GRCh38.primary_assembly.genome.fa --embedding_idx 42
-python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_nt_1000g_25b.csv nt InstaDeepAI/nucleotide-transformer-2.5b-1000g  data/genomes/GRCh38.primary_assembly.genome.fa --embedding_idx 42
-python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_nt_ms_25b.csv nt InstaDeepAI/nucleotide-transformer-2.5b-multi-species  data/genomes/GRCh38.primary_assembly.genome.fa --embedding_idx 42
-python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_nt_href_500m.csv nt InstaDeepAI/nucleotide-transformer-500m-human-ref  data/genomes/GRCh38.primary_assembly.genome.fa --embedding_idx 42
+python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_nt_1000g_500m.csv nt InstaDeepAI/nucleotide-transformer-500m-1000g  data/genomes/GRCh38.primary_assembly.genome.fa --embedding_idx 256
+python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_nt_1000g_25b.csv nt InstaDeepAI/nucleotide-transformer-2.5b-1000g  data/genomes/GRCh38.primary_assembly.genome.fa --embedding_idx 256
+python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_nt_ms_25b.csv nt InstaDeepAI/nucleotide-transformer-2.5b-multi-species  data/genomes/GRCh38.primary_assembly.genome.fa --embedding_idx 256
+python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_nt_href_500m.csv nt InstaDeepAI/nucleotide-transformer-500m-human-ref  data/genomes/GRCh38.primary_assembly.genome.fa --embedding_idx 256
 python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_hyenadna_tiny1k_512.csv hyenadna pretrained_models/hyenadna/hyenadna-tiny-1k-seqlen ../GRCh38.primary_assembly.genome.fa --extra_context 512 --embedding_idx 511 # autoreregressive
 python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_hyenadna_small32k_512.csv hyenadna pretrained_models/hyenadna/hyenadna-small-32k-seqlen ../GRCh38.primary_assembly.genome.fa --extra_context 512 --embedding_idx 511 # autoreregressive
 python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_hyenadna_medium160k_512.csv hyenadna pretrained_models/hyenadna/hyenadna-medium-160k-seqlen ../GRCh38.primary_assembly.genome.fa --extra_context 512 --embedding_idx 511 # autoreregressive
@@ -47,5 +47,5 @@ python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_
 python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_genalm_bigbird_base_t2t.csv genalm AIRI-Institute/gena-lm-bigbird-base-t2t ../GRCh38.primary_assembly.genome.fa --embedding_idx 256
 python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_convnet.csv convnet pretrained_models/convnet data/genomes/GRCh38.primary_assembly.genome.fa --embedding_idx 256
 python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_awd_lstm.csv awdlstm pretrained_models/awd_lstm data/genomes/GRCh38.primary_assembly.genome.fa --embedding_idx 511 --extra_context 512 #autoreregressive
-python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_nt_v2_500m.csv nt InstaDeepAI/nucleotide-transformer-v2-500m-multi-species data/genomes/GRCh38.primary_assembly.genome.fa --embedding_idx 42
+python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_nt_v2_500m.csv nt InstaDeepAI/nucleotide-transformer-v2-500m-multi-species data/genomes/GRCh38.primary_assembly.genome.fa --embedding_idx 256
 python3 scripts/predict_variant_effects.py $VARIANT_FILE $OUT_DIR/${OUT_PREFIX}_grover.csv grover pretrained_models/grover data/genomes/GRCh38.primary_assembly.genome.fa --embedding_idx 256


### PR DESCRIPTION
This PR adds the GROVER DNA LM and fixes some issues.

- GROVER added (embedder, tokenization using max match algorithm, auto download util for zenodo)
- Fix some bugs for variant effect prediction (#48 #49)
- Fix an indexing bug in variant effects prediction with AWD-LSTM
- Standardize `load_checkpoint` in hydra config to `False`
- Fix `epochs: 100` for enhancer annotation
- Changed metrics computation in the trainer class to always handle lists, with the summary metric returned in `metrics[0]`