### PR TITLE
fix: crash at higher wandb versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ torch>=2.0.1
 tqdm>=4.65.0
 transformers>=4.30.1,<=4.33.3
 hydra-core>=1.3.1
-wandb==0.13.5
+wandb>=0.19.7
 einops
 torchvision
 hydra-joblib-launcher

--- a/scripts/train_on_task.py
+++ b/scripts/train_on_task.py
@@ -25,14 +25,15 @@ def run_experiment(cfg: DictConfig) -> None:
     cfg : DictConfig
         Hydra configuration object.
     """
-    wandb.config = OmegaConf.to_container(
-        cfg, resolve=True, throw_on_missing=True
-        )
     # mkdir output_dir 
     os.makedirs(f'{cfg.output_dir}/checkpoints/', exist_ok=True)
     print('output_dir', cfg.output_dir)
     # init wandb
-    run = wandb.init(**cfg.wandb, dir = cfg.output_dir, config = cfg)
+    run = wandb.init(
+        **cfg.wandb,
+        dir=cfg.output_dir,
+        config=OmegaConf.to_container(cfg, resolve=True, throw_on_missing=True),
+    )
     
     OmegaConf.save(cfg, f"{cfg.output_dir}/config.yaml") # save the config to the experiment dir
     # set device 


### PR DESCRIPTION
Hi,

The dependency `wandb` was pinned to version `0.13.5` as it broke for higher versions (see issue #39).
I've updated `wandb` as the pinned version requires a `numpy` version below Numpy 2 and this lead a conflict with some other dependencies.
Apparently, something changed in the handling of the config parameter, so passing it as a `OmegaConf.DictConfig` object is not longer possible. Calling `OmegaConf.to_container` on it converts it to a primitive that wandb can handle.
This way `wandb` can be updated to the latest version.

This PR:
* updates `wandb` to the latest version
* modifies the `wandb.init` call to directly pass the resolved and containerized `cfg` configuration, ensuring all necessary parameters are included

Best,
Zeno