### PR TITLE
fix: allow to load model with unrestricted unpickler

### DIFF
--- a/bend/utils/task_trainer.py
+++ b/bend/utils/task_trainer.py
@@ -230,7 +230,7 @@ class BaseTrainer:
         return 
     
     def _load_checkpoint(self, checkpoint):
-        checkpoint = torch.load(checkpoint,  map_location=self.device)
+        checkpoint = torch.load(checkpoint, map_location=self.device, weights_only=False)
         try:
             self.model.load_state_dict(checkpoint['model_state_dict'], strict=True)
         except:


### PR DESCRIPTION
Hi,

In PyTorch 2.6, the default value of the `weights_only` argument in `torch.load` was changed from False to True. This PR explicitly adds `weights_only=False` to the `torch.load` call to restore this old default behavior.

Currently, running the code before the PR using PyTorch 2.6 leads to a `_pickle.UnpicklingError` that is also documented [here](https://pytorch.org/docs/stable/notes/serialization.html#torch-load-with-weights-only-true).

Best,
Zeno